### PR TITLE
fix: 未使用変数を削除してShellCheckのエラーを解消

### DIFF
--- a/scripts/android_setup.sh
+++ b/scripts/android_setup.sh
@@ -3,9 +3,6 @@ set -euo pipefail
 
 echo "「Android」のセットアップを開始しました"
 
-# Homebrew のコマンドラインツール群
-CMDLINE_TOOLS_ROOT="/opt/homebrew/share/android-commandlinetools"
-
 # SDK 全体を指すディレクトリ（IDE からはこっちを見せる）
 SDK_ROOT="$HOME/Library/Android/sdk"
 


### PR DESCRIPTION
## 概要

`main` で落ちていた Shell Script Lint（ShellCheck）を修正します。

## 原因

`scripts/android_setup.sh` の `CMDLINE_TOOLS_ROOT` が未使用で、SC2034 が出ていました。

81dbaf8 のリライトで、旧 `SDK_DIR` が `CMDLINE_TOOLS_ROOT` にリネームされた一方、参照側（`sdkmanager --sdk_root` と `flutter config --android-sdk`）は新設の `SDK_ROOT` に統一されたため、この変数だけ参照元がない状態で残っていました。リポジトリ全体を検索しても他に参照はありません。

## 変更内容

未使用となっていた `CMDLINE_TOOLS_ROOT` の定義を削除しました。`sdkmanager` は `command -v` で PATH から解決しているため、動作への影響はありません。

## 動作確認

CI と同じコマンドをローカルで実行し、エラーが解消されたことを確認しました。

```
$ find . -type f -name '*.sh' -not -path './.github/*' -print0 | xargs -0 shellcheck --shell=bash
$ echo $?
0
```

`zsh -n scripts/android_setup.sh` による構文チェックも通っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)