### PR TITLE
feat: Claudeのセットアップ設定を追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline-command.sh"
+  },
+  "theme": "dark"
+}

--- a/scripts/setup/link_dotfiles.sh
+++ b/scripts/setup/link_dotfiles.sh
@@ -16,6 +16,7 @@ LINKS=(
   "$DOTFILES_DIR/asdf/.tool-versions:$HOME/.tool-versions"
   "$DOTFILES_DIR/aws/config:$HOME/.aws/config"
   "$DOTFILES_DIR/vscode/settings.json:$HOME/Library/Application Support/Code/User/settings.json"
+  "$DOTFILES_DIR/claude/settings.json:$HOME/.claude/settings.json"
   "$DOTFILES_DIR/android/sdk:$HOME/Library/Android/sdk"
   "/opt/homebrew/share/android-commandlinetools/cmdline-tools/latest:$HOME/Library/Android/sdk/cmdline-tools/latest"
 )


### PR DESCRIPTION
## やったこと

- [x] Claude Code の設定を dotfiles 管理下に追加
- [x] シンボリックリンクの作成対象に追加

## 変更内容

Claude Code の設定を管理する `claude/` を新設し、`settings.json` を追加しました。既存の `vscode/settings.json` と同じ扱いです。

`scripts/setup/link_dotfiles.sh` のリンク一覧にも追加したので、セットアップ時に `~/.claude/settings.json` へリンクが張られます。

## 動作確認

- `jq empty claude/settings.json` で JSON として妥当なことを確認
- CI と同じ ShellCheck を実行して exit 0
- `zsh -n scripts/setup/link_dotfiles.sh` の構文チェックを通過
- 設定内にトークン・鍵などの秘密情報が含まれないことを確認

## 補足

`settings.json` から参照している `~/.claude/statusline-command.sh` 本体は別 PR で追加します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)