### PR TITLE
feat: Claudeをcaffeinate経由で起動するaliasを追加

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -29,3 +29,6 @@ fi
 export ANDROID_SDK_ROOT="$HOME/Library/Android/sdk"
 export PATH="$PATH:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/tools/bin"
 export PATH="$HOME/Library/Python/3.9/bin:$PATH"
+
+# Claude Code をスリープさせずに実行
+alias claude="caffeinate -ims $HOME/.local/bin/claude"


### PR DESCRIPTION
## やったこと

- [x] `claude` を `caffeinate` 経由で起動する alias を追加

## 変更内容

`zsh/.zshrc` に以下を追加しました。

```zsh
# Claude Code をスリープさせずに実行
alias claude="caffeinate -ims $HOME/.local/bin/claude"
```

Claude Code の実行中だけスリープを抑止し、終了すると自動で解除されます。蓋を開けたままなら、バッテリー駆動でも動き続けます。

## フラグの内訳

| フラグ | 効果 | 電源条件 |
| --- | --- | --- |
| `-i` | アイドルによるシステムスリープを抑止 | バッテリーでも有効 |
| `-m` | ディスクのアイドルスリープを抑止 | 常時 |
| `-s` | システムスリープ自体を抑止 | AC 接続時のみ |

`-d`（ディスプレイのスリープ抑止）は含めていません。画面が暗くなってもシステムはスリープしないため、実行の継続には不要です。

## 動作確認

- `caffeinate -ims` 実行中に `pmset -g assertions` を確認し、`PreventUserIdleSystemSleep` が立つことを確認（バッテリー駆動時に実測）
- alias 経由で `claude --version` が正常に動作することを確認
- `zsh -n zsh/.zshrc` の構文チェックを通過

## 補足

- 実体を絶対パスで指定しているため、alias の再帰は起きません
- 素の `claude` を実行したい場合は `command claude` で呼べます
- 蓋を閉じた場合のスリープは `caffeinate` では抑止できません

🤖 Generated with [Claude Code](https://claude.com/claude-code)