### PR TITLE
feat: Claude Codeのインストールをセットアップに追加

### DIFF
--- a/scripts/setup/claude_setup.sh
+++ b/scripts/setup/claude_setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+echo "「Claude Code」のセットアップを開始しました"
+
+# Claude Codeのインストール
+if ! command -v claude >/dev/null 2>&1; then
+  echo "「Claude Code」が見つかりません。インストールを開始します..."
+  curl -fsSL https://claude.ai/install.sh | bash
+else
+  echo "「Claude Code」は既にインストールされています"
+fi
+
+echo "「Claude Code」のセットアップが完了しました"

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -11,5 +11,6 @@ sh "$INSTALL_DIR/scripts/setup/asdf_setup.sh"
 sh "$INSTALL_DIR/scripts/setup/vscode_setup.sh"
 sh "$INSTALL_DIR/scripts/setup/xcode_setup.sh"
 sh "$INSTALL_DIR/scripts/setup/android_setup.sh"
+sh "$INSTALL_DIR/scripts/setup/claude_setup.sh"
 
 echo "「dotfiles」のセットアップが完了しました"


### PR DESCRIPTION
## やったこと

- [x] Claude Code をインストールするスクリプトを追加
- [x] セットアップの実行対象に追加

## 変更内容

これまで Claude Code だけ dotfiles からインストールできず、手動での導入が必要でした。`scripts/setup/claude_setup.sh` を追加し、`scripts/setup/setup.sh` から呼ぶようにしています。

インストール方法は、公式ドキュメントで Recommended とされているネイティブインストーラを使います。

```
curl -fsSL https://claude.ai/install.sh | bash
```

Homebrew の cask（`claude-code`）でも導入できますが、以下の理由でネイティブインストーラを選びました。

- 自動更新が効く（Homebrew 版は `brew upgrade claude-code` が必要）
- インストール先が `~/.local/bin/claude` になり、既存の環境と一致する
- 公式が推奨している

既存の `homebrew_setup.sh` と同じく、インストール済みなら何もしない作りです。

## 動作確認

- CI と同じ ShellCheck を実行して exit 0
- `zsh -n` の構文チェックを通過
- インストール済みの環境で実行し、スキップされることを確認（`zsh` 直接実行と、`setup.sh` と同じ `sh` 経由の両方で exit 0）
- 参照先 URL が HTTP 200 / `text/x-sh` を返すことを確認

## 補足

Claude Code は `~/.local/bin` に入りますが、`zsh/.zshrc` にこのパスが通っていません。別途対応が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
