### PR TITLE
fix: 重複していたCocoaPodsのインストールを削除

### DIFF
--- a/scripts/setup/xcode_setup.sh
+++ b/scripts/setup/xcode_setup.sh
@@ -3,9 +3,6 @@ set -euo pipefail
 
 echo "「Xcode」のセットアップを開始しました"
 
-# podのインストール
-gem install cocoapods
-
 # xcodebuildのライセンスを受諾
 yes | sudo xcodebuild -license accept || true
 


### PR DESCRIPTION
## やったこと

- [x] `xcode_setup.sh` から重複していた CocoaPods のインストールを削除

Closes #37

## 背景

CocoaPods は Brewfile の `brew "cocoapods"` で既にインストールされています。`homebrew_setup.sh` の `brew bundle` で処理されるため、実行順の都合で `xcode_setup.sh` に到達する時点では導入済みです。

```
scripts/setup/setup.sh
  1. link_dotfiles.sh
  2. homebrew_setup.sh   ← brew bundle で cocoapods が入る
  ...
  5. xcode_setup.sh      ← gem install cocoapods（重複）
```

そのうえで `gem install cocoapods` はシステム Ruby（`/usr/bin/gem`）を使うため、`/Library/Ruby` への書き込み権限がなく失敗します。仮に成功しても Homebrew 版と二重管理になります。

## 変更内容

```diff
-# podのインストール
-gem install cocoapods
-
 # xcodebuildのライセンスを受諾
 yes | sudo xcodebuild -license accept || true
```

CocoaPods 自体は Brewfile 経由で入るため、この削除で使えなくなることはありません。

## 動作確認

- `pod` の提供元が Homebrew であることを確認（`/opt/homebrew/Cellar/cocoapods/1.16.2_1/bin/pod`）
- `pod --version` が `1.16.2` を返すことを確認
- CI と同じ ShellCheck を実行して exit 0
- `zsh -n` の構文チェックを通過

## 補足

Issue #37 の「パスワードなしで突破できないか」について、残る `sudo xcodebuild -license accept` は Xcode のライセンス同意をシステム全体に書き込むもので、root 権限が必須です。こちらはパスワードなしにはできないため、今回の変更対象外としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
