### PR TITLE
feat: Intel MacとApple Siliconの両方に対応

### DIFF
--- a/scripts/setup/android_setup.sh
+++ b/scripts/setup/android_setup.sh
@@ -6,6 +6,13 @@ echo "「Android」のセットアップを開始しました"
 # SDK 全体を指すディレクトリ（IDE からはこっちを見せる）
 SDK_ROOT="$HOME/Library/Android/sdk"
 
+# エミュレータのシステムイメージ（Apple Silicon: arm64-v8a、Intel: x86_64）
+if [ "$(uname -m)" = "arm64" ]; then
+  SYSTEM_IMAGE_ABI="arm64-v8a"
+else
+  SYSTEM_IMAGE_ABI="x86_64"
+fi
+
 # Homebrew 版の sdkmanager が使えるか確認
 if ! command -v sdkmanager >/dev/null; then
   echo "ERROR: sdkmanager が見つかりません。PATH を確認してください。" >&2
@@ -17,7 +24,7 @@ sdkmanager --sdk_root="$SDK_ROOT" \
               "cmdline-tools;latest" \
               "platform-tools" \
               "platforms;android-35" \
-              "system-images;android-35;google_apis_playstore;arm64-v8a" \
+              "system-images;android-35;google_apis_playstore;$SYSTEM_IMAGE_ABI" \
               "build-tools;35.0.1" \
               "build-tools;36.0.0" \
               "sources;android-35" \

--- a/scripts/setup/link_dotfiles.sh
+++ b/scripts/setup/link_dotfiles.sh
@@ -5,6 +5,13 @@ echo "「シンボリックリンク」の作成を開始しました"
 
 DOTFILES_DIR="$HOME/dotfiles"
 
+# Homebrewのインストール先（Apple Silicon: /opt/homebrew、Intel: /usr/local）
+if [ "$(uname -m)" = "arm64" ]; then
+  BREW_PREFIX="/opt/homebrew"
+else
+  BREW_PREFIX="/usr/local"
+fi
+
 # リンクを作成するファイル一覧（キー：シンボリックリンク先、値：dotfiles内の実ファイル）
 LINKS=(
   "$DOTFILES_DIR/zsh/.zshrc:$HOME/.zshrc"
@@ -19,7 +26,7 @@ LINKS=(
   "$DOTFILES_DIR/claude/settings.json:$HOME/.claude/settings.json"
   "$DOTFILES_DIR/claude/statusline-command.sh:$HOME/.claude/statusline-command.sh"
   "$DOTFILES_DIR/android/sdk:$HOME/Library/Android/sdk"
-  "/opt/homebrew/share/android-commandlinetools/cmdline-tools/latest:$HOME/Library/Android/sdk/cmdline-tools/latest"
+  "$BREW_PREFIX/share/android-commandlinetools/cmdline-tools/latest:$HOME/Library/Android/sdk/cmdline-tools/latest"
 )
 
 # すべてのリンクを作成

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,5 +1,9 @@
-# Homebrew
-eval "$(/opt/homebrew/bin/brew shellenv)"
+# Homebrew（Apple Silicon: /opt/homebrew、Intel: /usr/local）
+if [ -x /opt/homebrew/bin/brew ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
 
 # OrbStack
 source ~/.orbstack/shell/init.zsh 2>/dev/null || :


### PR DESCRIPTION
## やったこと

- [x] Homebrew のインストール先をアーキテクチャで切り替え
- [x] Android エミュレータのシステムイメージをアーキテクチャで切り替え

Closes #12

## 背景

Apple Silicon 前提のパスがハードコードされており、Intel Mac では動作しませんでした。リポジトリ全体を調べたところ、該当は以下の 3 箇所でした。

| 箇所 | 内容 |
| --- | --- |
| `zsh/.zshenv` | `eval "$(/opt/homebrew/bin/brew shellenv)"` |
| `scripts/setup/link_dotfiles.sh` | `/opt/homebrew/share/android-commandlinetools/...` |
| `scripts/setup/android_setup.sh` | `system-images;...;arm64-v8a` |

Homebrew は Apple Silicon で `/opt/homebrew`、Intel で `/usr/local` に入ります。Android のシステムイメージも CPU に合わせて `arm64-v8a` と `x86_64` を使い分ける必要があります。

## 変更内容

**zsh/.zshenv**

実際に存在する方を使います。`brew --prefix` は brew 自体に PATH が通っていないと使えないため、パスの存在確認で判定しています。

```zsh
if [ -x /opt/homebrew/bin/brew ]; then
  eval "$(/opt/homebrew/bin/brew shellenv)"
elif [ -x /usr/local/bin/brew ]; then
  eval "$(/usr/local/bin/brew shellenv)"
fi
```

**scripts/setup/link_dotfiles.sh / scripts/setup/android_setup.sh**

`uname -m` で判定します。`link_dotfiles.sh` は `setup.sh` の最初に実行され、この時点では Homebrew 未インストールの可能性があるため、brew に依存しない判定にしています。

```zsh
if [ "$(uname -m)" = "arm64" ]; then
  BREW_PREFIX="/opt/homebrew"
else
  BREW_PREFIX="/usr/local"
fi
```

## 動作確認

`uname` を差し替えて、両アーキテクチャでの分岐を確認しました。

```
uname -m = arm64    → BREW_PREFIX=/opt/homebrew  ABI=arm64-v8a
uname -m = x86_64   → BREW_PREFIX=/usr/local     ABI=x86_64
```

`.zshenv` は brew の配置を変えた 3 パターンで確認しました。

```
Apple Silicon 相当（/opt/homebrew に brew あり） → /opt/homebrew 側を使用
Intel 相当（/usr/local に brew あり）            → /usr/local 側を使用
brew 未インストール                              → エラーなしで通過
```

3 つ目は今回の副次的な改善です。従来は brew が無いと `no such file or directory` が出ていましたが、分岐を入れたことで無害に通過するようになりました。

あわせて以下も確認しています。

- CI と同じ ShellCheck を実行して exit 0
- `zsh -n` の構文チェックを通過（3 ファイルとも）
- `/opt/homebrew` と `arm64-v8a` のハードコードが、分岐の内側以外に残っていないこと

## 補足

手元が Apple Silicon のため、Intel 実機での通しの動作確認はできていません。分岐ロジックは上記の通り両方で検証済みですが、実機での確認は必要に応じてお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
