### PR TITLE
feat: Claude Codeの設定を追加

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,5 +3,11 @@
     "type": "command",
     "command": "~/.claude/statusline-command.sh"
   },
-  "theme": "dark"
+  "permissions": {
+    "defaultMode": "auto"
+  },
+  "effortLevel": "xhigh",
+  "tui": "fullscreen",
+  "theme": "dark-ansi",
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## 概要

`claude/settings.json` に Claude Code の設定を追加する。

## 変更内容

- `permissions.defaultMode` を `auto` に設定
- `effortLevel` を `xhigh` に設定
- `tui` を `fullscreen` に設定
- `theme` を `dark` から `dark-ansi` に変更
- `skipAutoPermissionPrompt` を `true` に設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)